### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     env:
       CI: true


### PR DESCRIPTION
Potential fix for [https://github.com/queirozlc/paperhub/security/code-scanning/1](https://github.com/queirozlc/paperhub/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `test` job in the workflow file. This block should explicitly limit the `GITHUB_TOKEN` permissions to the minimum required for the job. Since the `test` job does not perform any write operations, the permissions can be set to `contents: read`. This change ensures that the job adheres to the principle of least privilege and avoids inheriting potentially excessive permissions from the repository or organization settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
